### PR TITLE
feat: improve integration test suites

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ integration = [
     "pytest",
     "jubilant~=1.0",
     "kubernetes",
+    "tenacity",
 ]
 
 manifests =[

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -116,6 +116,7 @@ def kubernetes_cluster(juju: jubilant.Juju, request: pytest.FixtureRequest, arch
         constraints=constraints,
         base=base,
         config={"local-storage-enabled": False, "node-labels": "storagePool=primary"},
+        num_units=2,
     )
     juju.deploy(
         charm="k8s-worker",

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -233,9 +233,7 @@ class TestVolumeLifecycle:
                 node_selector={"storagePool": "primary"},
             ),
         ):
-            utils.wait_for_pvc_bound(
-                core_v1, pvc_name, namespace, timeout=utils.PVC_WAIT_TIMEOUT
-            )
+            utils.wait_for_pvc_bound(core_v1, pvc_name, namespace, timeout=utils.PVC_WAIT_TIMEOUT)
 
             pv_name = utils.get_pv_for_pvc(core_v1, pvc_name, namespace)
             assert pv_name is not None, f"PVC '{pvc_name}' is not bound to any PV"
@@ -290,9 +288,7 @@ class TestVolumeLifecycle:
                 node_selector={"storagePool": "primary"},
             ),
         ):
-            utils.wait_for_pvc_bound(
-                core_v1, pvc_name, namespace, timeout=utils.PVC_WAIT_TIMEOUT
-            )
+            utils.wait_for_pvc_bound(core_v1, pvc_name, namespace, timeout=utils.PVC_WAIT_TIMEOUT)
 
             pv_name = utils.get_pv_for_pvc(core_v1, pvc_name, namespace)
             assert pv_name is not None, f"PVC '{pvc_name}' is not bound to any PV"

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -2,69 +2,369 @@
 # Copyright 2025 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+"""Integration tests for the Rawfile LocalPV charm.
+
+These tests verify:
+- Multi-pool deployment with different storage classes
+- PVC provisioning and binding
+- Pod scheduling with node selectors
+- Data persistence across storage pools
+"""
+
 import logging
 from pathlib import Path
+from typing import List
 
 import jubilant
 import pytest
 import yaml
 from kubernetes import client, config, utils
-from utils import read_file_from_pod, wait_for_pod
+from utils import (
+    POD_WAIT_TIMEOUT,
+    PVC_WAIT_TIMEOUT,
+    create_pod_with_pvc,
+    create_pvc,
+    create_storage_class,
+    delete_pod,
+    delete_pv,
+    delete_pvc,
+    delete_storage_class,
+    get_pv_for_pvc,
+    get_pv_reclaim_policy,
+    k8s_resource_cleanup,
+    pv_exists,
+    read_file_from_pod,
+    verify_storage_class_exists,
+    wait_for_pod,
+    wait_for_pod_deleted,
+    wait_for_pv_deleted,
+    wait_for_pvc_bound,
+    wait_for_pvc_deleted,
+)
 
 logger = logging.getLogger(__name__)
 
 METADATA = yaml.safe_load(Path("charmcraft.yaml").read_text())
 APP_NAME = METADATA["name"]
 
+# Test resource names for cleanup tracking
+PRIMARY_RESOURCES = [
+    {"kind": "Pod", "name": "primary-pod"},
+    {"kind": "PersistentVolumeClaim", "name": "primary-pvc"},
+]
+SECONDARY_RESOURCES = [
+    {"kind": "Pod", "name": "secondary-pod"},
+    {"kind": "PersistentVolumeClaim", "name": "secondary-pvc"},
+]
+
 
 @pytest.mark.usefixtures("kubernetes_cluster")
-def test_deploy_pools(juju: jubilant.Juju, charm_path: Path):
-    juju.deploy(
-        charm=charm_path,
-        app="primary-localpv",
-        config={
-            "namespace": "primary",
-            "storage-class-name": "primary-sc",
-            "node-selector": "storagePool=primary",
-            "create-namespace": True,
-        },
-    )
-    juju.deploy(
-        charm=charm_path,
-        app="secondary-localpv",
-        config={
-            "namespace": "secondary",
-            "storage-class-name": "secondary-sc",
-            "node-selector": "storagePool=secondary",
-            "create-namespace": True,
-        },
-    )
+class TestDeployment:
+    """Test suite for charm deployment and configuration."""
 
-    juju.integrate("k8s", "primary-localpv:kubernetes")
-    juju.integrate("k8s", "secondary-localpv:kubernetes")
+    def test_deploy_pools(self, juju: jubilant.Juju, charm_path: Path):
+        """Test deploying multiple storage pools with different configurations.
 
-    juju.wait(jubilant.all_active)
+        This test verifies that:
+        - Multiple instances of the charm can be deployed
+        - Each instance can have its own namespace and storage class
+        - Node selectors are properly configured
+        - Charms reach active status after integration
+        """
+        juju.deploy(
+            charm=charm_path,
+            app="primary-localpv",
+            config={
+                "namespace": "primary",
+                "storage-class-name": "primary-sc",
+                "node-selector": "storagePool=primary",
+                "create-namespace": True,
+            },
+        )
+        juju.deploy(
+            charm=charm_path,
+            app="secondary-localpv",
+            config={
+                "namespace": "secondary",
+                "storage-class-name": "secondary-sc",
+                "node-selector": "storagePool=secondary",
+                "create-namespace": True,
+            },
+        )
+
+        juju.integrate("k8s", "primary-localpv:kubernetes")
+        juju.integrate("k8s", "secondary-localpv:kubernetes")
+
+        juju.wait(jubilant.all_active)
+
+    def test_storage_classes_created(self, kubeconfig: Path):
+        """Verify that storage classes are created after deployment.
+
+        This test ensures that the charm properly creates the configured
+        storage classes in the Kubernetes cluster.
+        """
+        config.load_kube_config(str(kubeconfig))
+        storage_api = client.StorageV1Api()
+
+        assert verify_storage_class_exists(storage_api, "primary-sc"), (
+            "Primary storage class 'primary-sc' was not created"
+        )
+        assert verify_storage_class_exists(storage_api, "secondary-sc"), (
+            "Secondary storage class 'secondary-sc' was not created"
+        )
 
 
 @pytest.mark.usefixtures("juju")
-def test_multiple_providers(kubeconfig: Path):
-    config.load_kube_config(str(kubeconfig))
-    api_client = client.ApiClient()
-    core_v1 = client.CoreV1Api(api_client)
-    manifests_path = Path("tests/integration/data")
-    primary_manifests = manifests_path / "primary-pod.yaml"
-    secondary_manifest = manifests_path / "secondary-pod.yaml"
+class TestStorageProvisioning:
+    """Test suite for storage provisioning and data persistence."""
 
-    for manifest_file in [primary_manifests, secondary_manifest]:
+    @staticmethod
+    def _load_manifests(manifest_file: Path) -> List[dict]:
+        """Load all manifests from a YAML file.
+
+        Args:
+            manifest_file: Path to the YAML manifest file.
+
+        Returns:
+            List of manifest dictionaries.
+        """
         with manifest_file.open() as f:
-            for manifest in yaml.safe_load_all(f):
-                utils.create_from_dict(api_client, manifest)
+            return list(yaml.safe_load_all(f))
 
-    wait_for_pod(core_v1, "primary-pod", "default", target_state="Running")
-    wait_for_pod(core_v1, "secondary-pod", "default", target_state="Running")
+    def test_multiple_providers(self, kubeconfig: Path):
+        """Test that multiple storage providers can provision volumes independently.
 
-    primary_content = read_file_from_pod(core_v1, "primary-pod", "/data/primary.txt")
-    assert primary_content == "Hello from primary!"
+        This test verifies:
+        - PVCs are created and bound using the correct storage class
+        - Pods are scheduled on nodes matching the storage pool
+        - Data can be written to and read from the provisioned volumes
+        - Each storage pool operates independently
 
-    secondary_content = read_file_from_pod(core_v1, "secondary-pod", "/data/secondary.txt")
-    assert secondary_content == "Hello from secondary!"
+        The test uses a cleanup context manager to ensure resources
+        are deleted even if the test fails.
+        """
+        config.load_kube_config(str(kubeconfig))
+        api_client = client.ApiClient()
+        core_v1 = client.CoreV1Api(api_client)
+        manifests_path = Path("tests/integration/data")
+        primary_manifests = manifests_path / "primary-pod.yaml"
+        secondary_manifest = manifests_path / "secondary-pod.yaml"
+
+        all_resources = PRIMARY_RESOURCES + SECONDARY_RESOURCES
+
+        with k8s_resource_cleanup(api_client, all_resources, namespace="default"):
+            # Create all resources from manifests
+            for manifest_file in [primary_manifests, secondary_manifest]:
+                for manifest in self._load_manifests(manifest_file):
+                    utils.create_from_dict(api_client, manifest)
+                    logger.info(
+                        "Created %s '%s'",
+                        manifest.get("kind"),
+                        manifest.get("metadata", {}).get("name"),
+                    )
+
+            # Wait for PVCs to be bound first (ensures storage provisioning works)
+            wait_for_pvc_bound(core_v1, "primary-pvc", "default", timeout=PVC_WAIT_TIMEOUT)
+            wait_for_pvc_bound(core_v1, "secondary-pvc", "default", timeout=PVC_WAIT_TIMEOUT)
+
+            # Wait for pods to be running
+            wait_for_pod(
+                core_v1,
+                "primary-pod",
+                "default",
+                target_state="Running",
+                timeout=POD_WAIT_TIMEOUT,
+            )
+            wait_for_pod(
+                core_v1,
+                "secondary-pod",
+                "default",
+                target_state="Running",
+                timeout=POD_WAIT_TIMEOUT,
+            )
+
+            # Verify data was written correctly to each storage pool
+            primary_content = read_file_from_pod(
+                core_v1, "primary-pod", "/data/primary.txt", namespace="default"
+            )
+            assert primary_content == "Hello from primary!", (
+                f"Expected 'Hello from primary!' but got '{primary_content}'"
+            )
+
+            secondary_content = read_file_from_pod(
+                core_v1, "secondary-pod", "/data/secondary.txt", namespace="default"
+            )
+            assert secondary_content == "Hello from secondary!", (
+                f"Expected 'Hello from secondary!' but got '{secondary_content}'"
+            )
+
+
+@pytest.mark.usefixtures("juju")
+class TestVolumeLifecycle:
+    """Test suite for volume lifecycle management and reclaim policies."""
+
+    CSI_DRIVER_BASE = "rawfile.csi.openebs.io"
+    # Use the primary app name
+    PRIMARY_APP_NAME = "primary-localpv"
+
+    @property
+    def csi_provisioner(self) -> str:
+        return f"{self.PRIMARY_APP_NAME}-{self.CSI_DRIVER_BASE}"
+
+    def test_volume_deletion_with_delete_policy(self, kubeconfig: Path):
+        """Test that PV is deleted when PVC is deleted with 'Delete' reclaim policy."""
+        config.load_kube_config(str(kubeconfig))
+        core_v1 = client.CoreV1Api()
+        storage_api = client.StorageV1Api()
+
+        sc_name = "test-delete-policy-sc"
+        pvc_name = "test-delete-policy-pvc"
+        pod_name = "test-delete-policy-pod"
+        namespace = "default"
+
+        try:
+            create_storage_class(
+                storage_api,
+                name=sc_name,
+                provisioner=self.csi_provisioner,
+                reclaim_policy="Delete",
+            )
+
+            create_pvc(
+                core_v1,
+                name=pvc_name,
+                namespace=namespace,
+                storage_class=sc_name,
+                size="1Gi",
+            )
+
+            create_pod_with_pvc(
+                core_v1,
+                pod_name=pod_name,
+                pvc_name=pvc_name,
+                namespace=namespace,
+                node_selector={"storagePool": "primary"},
+            )
+
+            wait_for_pvc_bound(core_v1, pvc_name, namespace, timeout=PVC_WAIT_TIMEOUT)
+
+            pv_name = get_pv_for_pvc(core_v1, pvc_name, namespace)
+            assert pv_name is not None, f"PVC '{pvc_name}' is not bound to any PV"
+
+            reclaim_policy = get_pv_reclaim_policy(core_v1, pv_name)
+            assert reclaim_policy == "Delete", (
+                f"Expected reclaim policy 'Delete' but got '{reclaim_policy}'"
+            )
+
+            delete_pod(core_v1, pod_name, namespace)
+            wait_for_pod_deleted(core_v1, pod_name, namespace)
+
+            delete_pvc(core_v1, pvc_name, namespace)
+
+            wait_for_pvc_deleted(core_v1, pvc_name, namespace)
+
+            wait_for_pv_deleted(core_v1, pv_name, timeout=PVC_WAIT_TIMEOUT)
+
+            logger.info("Successfully verified: PV '%s' was deleted after PVC deletion", pv_name)
+
+        finally:
+            try:
+                delete_pod(core_v1, pod_name, namespace)
+            except Exception:
+                pass
+            try:
+                delete_pvc(core_v1, pvc_name, namespace)
+            except Exception:
+                pass
+            try:
+                delete_storage_class(storage_api, sc_name)
+            except Exception:
+                pass
+
+    def test_volume_retain_policy(self, kubeconfig: Path):
+        """Test that PV is retained when PVC is deleted with 'Retain' reclaim policy."""
+        config.load_kube_config(str(kubeconfig))
+        core_v1 = client.CoreV1Api()
+        storage_api = client.StorageV1Api()
+
+        sc_name = "test-retain-policy-sc"
+        pvc_name = "test-retain-policy-pvc"
+        pod_name = "test-retain-policy-pod"
+        namespace = "default"
+        pv_name = None
+
+        try:
+            create_storage_class(
+                storage_api,
+                name=sc_name,
+                provisioner=self.csi_provisioner,
+                reclaim_policy="Retain",
+            )
+
+            create_pvc(
+                core_v1,
+                name=pvc_name,
+                namespace=namespace,
+                storage_class=sc_name,
+                size="1Gi",
+            )
+
+            create_pod_with_pvc(
+                core_v1,
+                pod_name=pod_name,
+                pvc_name=pvc_name,
+                namespace=namespace,
+                node_selector={"storagePool": "primary"},
+            )
+
+            wait_for_pvc_bound(core_v1, pvc_name, namespace, timeout=PVC_WAIT_TIMEOUT)
+
+            pv_name = get_pv_for_pvc(core_v1, pvc_name, namespace)
+            assert pv_name is not None, f"PVC '{pvc_name}' is not bound to any PV"
+
+            reclaim_policy = get_pv_reclaim_policy(core_v1, pv_name)
+            assert reclaim_policy == "Retain", (
+                f"Expected reclaim policy 'Retain' but got '{reclaim_policy}'"
+            )
+
+            delete_pod(core_v1, pod_name, namespace)
+            wait_for_pod_deleted(core_v1, pod_name, namespace)
+
+            delete_pvc(core_v1, pvc_name, namespace)
+
+            wait_for_pvc_deleted(core_v1, pvc_name, namespace)
+
+            assert pv_exists(core_v1, pv_name), (
+                f"PV '{pv_name}' was deleted but should have been retained"
+            )
+
+            pv = core_v1.read_persistent_volume(pv_name)
+            assert pv.status.phase == "Released", (
+                f"Expected PV status 'Released' but got '{pv.status.phase}'"
+            )
+
+            logger.info(
+                "Successfully verified: PV '%s' was retained after PVC deletion with status '%s'",
+                pv_name,
+                pv.status.phase,
+            )
+
+        finally:
+            try:
+                delete_pod(core_v1, pod_name, namespace)
+            except Exception:
+                pass
+            try:
+                delete_pvc(core_v1, pvc_name, namespace)
+            except Exception:
+                pass
+            if pv_name:
+                try:
+                    delete_pv(core_v1, pv_name)
+                    logger.info("Cleaned up retained PV '%s'", pv_name)
+                except Exception:
+                    pass
+            try:
+                delete_storage_class(storage_api, sc_name)
+            except Exception:
+                pass

--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -1,9 +1,13 @@
 # Copyright 2025 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+import functools
 import logging
 import pprint
 import shlex
+import time
+from contextlib import contextmanager
+from typing import Callable, Generator, List, Optional
 
 import pytest
 from kubernetes import client, stream, watch
@@ -11,24 +15,110 @@ from kubernetes.client.models import EventsV1EventList
 
 log = logging.getLogger(__name__)
 
+# Timeout constants (in seconds)
+POD_WAIT_TIMEOUT = 300
+PVC_WAIT_TIMEOUT = 120
+RETRY_INTERVAL = 5
+MAX_RETRIES = 10
+
+
+def retry(
+    max_attempts: int = MAX_RETRIES,
+    delay: int = RETRY_INTERVAL,
+    exceptions: tuple = (Exception,),
+) -> Callable:
+    """Retry a function on failure.
+
+    Args:
+        max_attempts: Maximum number of retry attempts.
+        delay: Delay between retries in seconds.
+        exceptions: Tuple of exceptions to catch and retry on.
+
+    Returns:
+        Decorated function with retry logic.
+    """
+
+    def decorator(func: Callable) -> Callable:
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            last_exception = None
+            for attempt in range(1, max_attempts + 1):
+                try:
+                    return func(*args, **kwargs)
+                except exceptions as e:
+                    last_exception = e
+                    log.warning(
+                        "Attempt %d/%d for %s failed: %s",
+                        attempt,
+                        max_attempts,
+                        func.__name__,
+                        e,
+                    )
+                    if attempt < max_attempts:
+                        time.sleep(delay)
+            raise last_exception
+
+        return wrapper
+
+    return decorator
+
+
+def wait_for_pvc_bound(
+    core_api: client.CoreV1Api,
+    name: str,
+    namespace: str,
+    timeout: int = PVC_WAIT_TIMEOUT,
+) -> None:
+    """Wait for a PVC to become Bound.
+
+    Args:
+        core_api: Instance of CoreV1 kubernetes api.
+        name: Name of the PVC.
+        namespace: Namespace of the PVC.
+        timeout: Maximum seconds to wait for PVC to become Bound.
+
+    Raises:
+        pytest.fail: If PVC does not become Bound within timeout.
+    """
+    k8s_watch = watch.Watch()
+    log.info("Waiting for PVC '%s' in namespace '%s' to become Bound", name, namespace)
+
+    for event in k8s_watch.stream(
+        func=core_api.list_namespaced_persistent_volume_claim,
+        namespace=namespace,
+        timeout_seconds=timeout,
+    ):
+        resource = event["object"]
+        if resource.metadata.name != name:
+            continue
+        pvc_phase = resource.status.phase
+        log.debug("PVC %s phase: %s", name, pvc_phase)
+        if pvc_phase == "Bound":
+            log.info("PVC '%s' is now Bound", name)
+            k8s_watch.stop()
+            return
+
+    pytest.fail(f"Timeout after {timeout}s waiting for PVC '{name}' to become Bound")
+
 
 def wait_for_pod(
     core_api: client.CoreV1Api,
     name: str,
     namespace: str,
-    timeout: int = 120,
+    timeout: int = POD_WAIT_TIMEOUT,
     target_state: str = "Running",
 ) -> None:
     """Wait for kubernetes pod to reach desired state.
 
-    If the state is not reached within specified timeout, pytest.fail is executed.
+    Args:
+        core_api: Instance of CoreV1 kubernetes api.
+        name: Name of the kubernetes pod.
+        namespace: Namespace in which the pod is running.
+        timeout: Maximum seconds to wait for pod to reach target_state.
+        target_state: Expected pod status (e.g.: Running or Succeeded).
 
-    :param core_api: instance of CoreV1 kubernetes api.
-    :param name: name of the kubernetes pod.
-    :param namespace: namespace in which the pod is running
-    :param timeout: Maximum seconds to wait for pod to reach target_state
-    :param target_state: Expected pod status. (e.g.: Running or Succeeded)
-    :return: None
+    Raises:
+        pytest.fail: If pod does not reach target_state within timeout.
     """
     k8s_watch = watch.Watch()
 
@@ -40,9 +130,14 @@ def wait_for_pod(
         if resource.metadata.name != name:
             continue
         pod_state = resource.status.phase
-        log.debug("%s state: %s", name, pod_state)
+        log.debug("Pod '%s' state: %s (waiting for %s)", name, pod_state, target_state)
         if pod_state == target_state:
-            break
+            log.info("Pod '%s' reached target state '%s'", name, target_state)
+            k8s_watch.stop()
+            return
+        if pod_state == "Failed":
+            k8s_watch.stop()
+            pytest.fail(f"Pod '{name}' entered Failed state")
     else:
         log.info(f"Pod failed to start within allotted timeout: '{timeout}s'")
         events: EventsV1EventList = core_api.list_namespaced_event(
@@ -60,23 +155,494 @@ def wait_for_pod(
         )
 
 
+@retry(max_attempts=5, delay=2, exceptions=(Exception,))
 def read_file_from_pod(
-    core_v1: client.CoreV1Api, pod_name: str, file_path: str, namespace="default"
-):
-    """Read a file from a pod using kubernetes exec."""
+    core_v1: client.CoreV1Api,
+    pod_name: str,
+    file_path: str,
+    namespace: str = "default",
+    container: Optional[str] = None,
+) -> str:
+    """Read a file from a pod using kubernetes exec.
+
+    This function includes retry logic to handle transient failures
+    that may occur when the pod is still initializing.
+
+    Args:
+        core_v1: Instance of CoreV1 kubernetes api.
+        pod_name: Name of the pod to read from.
+        file_path: Path to the file inside the pod.
+        namespace: Namespace of the pod.
+        container: Specific container name (optional).
+
+    Returns:
+        Contents of the file as a string.
+
+    Raises:
+        Exception: If file cannot be read after all retries.
+    """
     exec_cmd = ["/bin/sh", "-c", f"cat {shlex.quote(file_path)}"]
+    kwargs = {
+        "command": exec_cmd,
+        "stderr": True,
+        "stdin": False,
+        "stdout": True,
+        "tty": False,
+    }
+    if container:
+        kwargs["container"] = container
+
     try:
         resp = stream.stream(
             core_v1.connect_get_namespaced_pod_exec,
             pod_name,
             namespace,
-            command=exec_cmd,
-            stderr=True,
-            stdin=False,
-            stdout=True,
-            tty=False,
+            **kwargs,
         )
-        return resp.strip()
+        content = resp.strip()
+        log.debug("Read %d bytes from %s:%s", len(content), pod_name, file_path)
+        return content
     except Exception as e:
-        log.error(f"Failed to read file {file_path} from pod {pod_name}: {e}")
+        log.error("Failed to read file %s from pod %s: %s", file_path, pod_name, e)
         raise
+
+
+@contextmanager
+def k8s_resource_cleanup(
+    api_client: client.ApiClient,
+    resources: List[dict],
+    namespace: str = "default",
+) -> Generator[None, None, None]:
+    """Context manager to ensure K8s resources are cleaned up after tests.
+
+    Args:
+        api_client: Kubernetes API client.
+        resources: List of resource dicts with 'kind' and 'name' keys.
+        namespace: Namespace of the resources.
+
+    Yields:
+        None
+    """
+    core_v1 = client.CoreV1Api(api_client)
+    try:
+        yield
+    finally:
+        for resource in resources:
+            kind = resource.get("kind", "").lower()
+            name = resource.get("name", "")
+            try:
+                if kind == "pod":
+                    core_v1.delete_namespaced_pod(name, namespace, grace_period_seconds=0)
+                    log.info("Deleted pod '%s'", name)
+                elif kind == "persistentvolumeclaim":
+                    core_v1.delete_namespaced_persistent_volume_claim(name, namespace)
+                    log.info("Deleted PVC '%s'", name)
+            except client.ApiException as e:
+                if e.status != 404:
+                    log.warning("Failed to delete %s '%s': %s", kind, name, e)
+
+
+def verify_storage_class_exists(
+    storage_api: client.StorageV1Api,
+    name: str,
+) -> bool:
+    """Verify that a storage class exists.
+
+    Args:
+        storage_api: Instance of StorageV1 kubernetes api.
+        name: Name of the storage class.
+
+    Returns:
+        True if the storage class exists, False otherwise.
+    """
+    try:
+        storage_api.read_storage_class(name)
+        log.info("Storage class '%s' exists", name)
+        return True
+    except client.ApiException as e:
+        if e.status == 404:
+            log.warning("Storage class '%s' not found", name)
+            return False
+        raise
+
+
+def wait_for_pvc_deleted(
+    core_api: client.CoreV1Api,
+    name: str,
+    namespace: str,
+    timeout: int = PVC_WAIT_TIMEOUT,
+) -> None:
+    """Wait for a PVC to be deleted.
+
+    Args:
+        core_api: Instance of CoreV1 kubernetes api.
+        name: Name of the PVC.
+        namespace: Namespace of the PVC.
+        timeout: Maximum seconds to wait for PVC deletion.
+
+    Raises:
+        pytest.fail: If PVC is not deleted within timeout.
+    """
+    log.info("Waiting for PVC '%s' to be deleted", name)
+    start_time = time.time()
+
+    while time.time() - start_time < timeout:
+        try:
+            core_api.read_namespaced_persistent_volume_claim(name, namespace)
+            log.debug("PVC '%s' still exists, waiting...", name)
+            time.sleep(RETRY_INTERVAL)
+        except client.ApiException as e:
+            if e.status == 404:
+                log.info("PVC '%s' has been deleted", name)
+                return
+            raise
+
+    pytest.fail(f"Timeout after {timeout}s waiting for PVC '{name}' to be deleted")
+
+
+def wait_for_pv_deleted(
+    core_api: client.CoreV1Api,
+    name: str,
+    timeout: int = PVC_WAIT_TIMEOUT,
+) -> None:
+    """Wait for a PV to be deleted.
+
+    Args:
+        core_api: Instance of CoreV1 kubernetes api.
+        name: Name of the PV.
+        timeout: Maximum seconds to wait for PV deletion.
+
+    Raises:
+        pytest.fail: If PV is not deleted within timeout.
+    """
+    log.info("Waiting for PV '%s' to be deleted", name)
+    start_time = time.time()
+
+    while time.time() - start_time < timeout:
+        try:
+            core_api.read_persistent_volume(name)
+            log.debug("PV '%s' still exists, waiting...", name)
+            time.sleep(RETRY_INTERVAL)
+        except client.ApiException as e:
+            if e.status == 404:
+                log.info("PV '%s' has been deleted", name)
+                return
+            raise
+
+    pytest.fail(f"Timeout after {timeout}s waiting for PV '{name}' to be deleted")
+
+
+def get_pv_for_pvc(
+    core_api: client.CoreV1Api,
+    pvc_name: str,
+    namespace: str,
+) -> Optional[str]:
+    """Get the PV name bound to a PVC.
+
+    Args:
+        core_api: Instance of CoreV1 kubernetes api.
+        pvc_name: Name of the PVC.
+        namespace: Namespace of the PVC.
+
+    Returns:
+        Name of the bound PV, or None if not bound.
+    """
+    try:
+        pvc = core_api.read_namespaced_persistent_volume_claim(pvc_name, namespace)
+        pv_name = pvc.spec.volume_name
+        log.info("PVC '%s' is bound to PV '%s'", pvc_name, pv_name)
+        return pv_name
+    except client.ApiException as e:
+        if e.status == 404:
+            log.warning("PVC '%s' not found", pvc_name)
+            return None
+        raise
+
+
+def pv_exists(
+    core_api: client.CoreV1Api,
+    name: str,
+) -> bool:
+    """Check if a PV exists.
+
+    Args:
+        core_api: Instance of CoreV1 kubernetes api.
+        name: Name of the PV.
+
+    Returns:
+        True if the PV exists, False otherwise.
+    """
+    try:
+        core_api.read_persistent_volume(name)
+        return True
+    except client.ApiException as e:
+        if e.status == 404:
+            return False
+        raise
+
+
+def get_pv_reclaim_policy(
+    core_api: client.CoreV1Api,
+    name: str,
+) -> Optional[str]:
+    """Get the reclaim policy of a PV.
+
+    Args:
+        core_api: Instance of CoreV1 kubernetes api.
+        name: Name of the PV.
+
+    Returns:
+        The reclaim policy string (e.g., 'Delete', 'Retain'), or None if PV not found.
+    """
+    try:
+        pv = core_api.read_persistent_volume(name)
+        return pv.spec.persistent_volume_reclaim_policy
+    except client.ApiException as e:
+        if e.status == 404:
+            return None
+        raise
+
+
+def create_storage_class(
+    storage_api: client.StorageV1Api,
+    name: str,
+    provisioner: str,
+    reclaim_policy: str = "Delete",
+    volume_binding_mode: str = "WaitForFirstConsumer",
+    parameters: Optional[dict] = None,
+) -> None:
+    """Create a storage class.
+
+    Args:
+        storage_api: Instance of StorageV1 kubernetes api.
+        name: Name of the storage class.
+        provisioner: CSI provisioner name.
+        reclaim_policy: Reclaim policy ('Delete' or 'Retain').
+        volume_binding_mode: Volume binding mode.
+        parameters: Optional storage class parameters.
+    """
+    sc = client.V1StorageClass(
+        api_version="storage.k8s.io/v1",
+        kind="StorageClass",
+        metadata=client.V1ObjectMeta(name=name),
+        provisioner=provisioner,
+        reclaim_policy=reclaim_policy,
+        volume_binding_mode=volume_binding_mode,
+        parameters=parameters or {},
+    )
+    try:
+        storage_api.create_storage_class(sc)
+        log.info("Created storage class '%s' with reclaim policy '%s'", name, reclaim_policy)
+    except client.ApiException as e:
+        if e.status == 409:
+            log.warning("Storage class '%s' already exists", name)
+        else:
+            raise
+
+
+def delete_storage_class(
+    storage_api: client.StorageV1Api,
+    name: str,
+) -> None:
+    """Delete a storage class.
+
+    Args:
+        storage_api: Instance of StorageV1 kubernetes api.
+        name: Name of the storage class to delete.
+    """
+    try:
+        storage_api.delete_storage_class(name)
+        log.info("Deleted storage class '%s'", name)
+    except client.ApiException as e:
+        if e.status != 404:
+            raise
+
+
+def create_pvc(
+    core_api: client.CoreV1Api,
+    name: str,
+    namespace: str,
+    storage_class: str,
+    size: str = "1Gi",
+    access_modes: Optional[List[str]] = None,
+) -> None:
+    """Create a PersistentVolumeClaim.
+
+    Args:
+        core_api: Instance of CoreV1 kubernetes api.
+        name: Name of the PVC.
+        namespace: Namespace for the PVC.
+        storage_class: Storage class name.
+        size: Storage size (e.g., '1Gi').
+        access_modes: List of access modes. Defaults to ['ReadWriteOnce'].
+    """
+    if access_modes is None:
+        access_modes = ["ReadWriteOnce"]
+
+    pvc = client.V1PersistentVolumeClaim(
+        api_version="v1",
+        kind="PersistentVolumeClaim",
+        metadata=client.V1ObjectMeta(name=name, namespace=namespace),
+        spec=client.V1PersistentVolumeClaimSpec(
+            access_modes=access_modes,
+            resources=client.V1VolumeResourceRequirements(requests={"storage": size}),
+            storage_class_name=storage_class,
+        ),
+    )
+    try:
+        core_api.create_namespaced_persistent_volume_claim(namespace, pvc)
+        log.info("Created PVC '%s' in namespace '%s'", name, namespace)
+    except client.ApiException as e:
+        if e.status == 409:
+            log.warning("PVC '%s' already exists", name)
+        else:
+            raise
+
+
+def delete_pvc(
+    core_api: client.CoreV1Api,
+    name: str,
+    namespace: str,
+) -> None:
+    """Delete a PersistentVolumeClaim.
+
+    Args:
+        core_api: Instance of CoreV1 kubernetes api.
+        name: Name of the PVC.
+        namespace: Namespace of the PVC.
+    """
+    try:
+        core_api.delete_namespaced_persistent_volume_claim(name, namespace)
+        log.info("Deleted PVC '%s'", name)
+    except client.ApiException as e:
+        if e.status != 404:
+            raise
+
+
+def delete_pv(
+    core_api: client.CoreV1Api,
+    name: str,
+) -> None:
+    """Delete a PersistentVolume.
+
+    Args:
+        core_api: Instance of CoreV1 kubernetes api.
+        name: Name of the PV.
+    """
+    try:
+        core_api.delete_persistent_volume(name)
+        log.info("Deleted PV '%s'", name)
+    except client.ApiException as e:
+        if e.status != 404:
+            raise
+
+
+def create_pod_with_pvc(
+    core_api: client.CoreV1Api,
+    pod_name: str,
+    pvc_name: str,
+    namespace: str,
+    node_selector: Optional[dict] = None,
+    command: Optional[List[str]] = None,
+) -> None:
+    """Create a pod that uses a PVC.
+
+    Args:
+        core_api: Instance of CoreV1 kubernetes api.
+        pod_name: Name of the pod.
+        pvc_name: Name of the PVC to mount.
+        namespace: Namespace for the pod.
+        node_selector: Optional node selector dict.
+        command: Optional command to run. Defaults to sleep.
+    """
+    if command is None:
+        command = ["/bin/sh", "-c", "sleep 3600"]
+
+    pod = client.V1Pod(
+        api_version="v1",
+        kind="Pod",
+        metadata=client.V1ObjectMeta(name=pod_name, namespace=namespace),
+        spec=client.V1PodSpec(
+            node_selector=node_selector,
+            containers=[
+                client.V1Container(
+                    name="main",
+                    image="busybox",
+                    command=command,
+                    volume_mounts=[client.V1VolumeMount(name="data", mount_path="/data")],
+                )
+            ],
+            volumes=[
+                client.V1Volume(
+                    name="data",
+                    persistent_volume_claim=client.V1PersistentVolumeClaimVolumeSource(
+                        claim_name=pvc_name
+                    ),
+                )
+            ],
+        ),
+    )
+    try:
+        core_api.create_namespaced_pod(namespace, pod)
+        log.info("Created pod '%s' with PVC '%s'", pod_name, pvc_name)
+    except client.ApiException as e:
+        if e.status == 409:
+            log.warning("Pod '%s' already exists", pod_name)
+        else:
+            raise
+
+
+def delete_pod(
+    core_api: client.CoreV1Api,
+    name: str,
+    namespace: str,
+    grace_period: int = 0,
+) -> None:
+    """Delete a pod.
+
+    Args:
+        core_api: Instance of CoreV1 kubernetes api.
+        name: Name of the pod.
+        namespace: Namespace of the pod.
+        grace_period: Grace period in seconds for pod termination.
+    """
+    try:
+        core_api.delete_namespaced_pod(name, namespace, grace_period_seconds=grace_period)
+        log.info("Deleted pod '%s'", name)
+    except client.ApiException as e:
+        if e.status != 404:
+            raise
+
+
+def wait_for_pod_deleted(
+    core_api: client.CoreV1Api,
+    name: str,
+    namespace: str,
+    timeout: int = POD_WAIT_TIMEOUT,
+) -> None:
+    """Wait for a pod to be deleted.
+
+    Args:
+        core_api: Instance of CoreV1 kubernetes api.
+        name: Name of the pod.
+        namespace: Namespace of the pod.
+        timeout: Maximum seconds to wait for pod deletion.
+
+    Raises:
+        pytest.fail: If pod is not deleted within timeout.
+    """
+    log.info("Waiting for pod '%s' to be deleted", name)
+    start_time = time.time()
+
+    while time.time() - start_time < timeout:
+        try:
+            core_api.read_namespaced_pod(name, namespace)
+            log.debug("Pod '%s' still exists, waiting...", name)
+            time.sleep(RETRY_INTERVAL)
+        except client.ApiException as e:
+            if e.status == 404:
+                log.info("Pod '%s' has been deleted", name)
+                return
+            raise
+
+    pytest.fail(f"Timeout after {timeout}s waiting for pod '{name}' to be deleted")

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 
 [[package]]
@@ -588,6 +588,7 @@ integration = [
     { name = "jubilant" },
     { name = "kubernetes" },
     { name = "pytest" },
+    { name = "tenacity" },
 ]
 manifests = [
     { name = "packaging" },
@@ -617,6 +618,7 @@ integration = [
     { name = "jubilant", specifier = "~=1.0" },
     { name = "kubernetes" },
     { name = "pytest" },
+    { name = "tenacity" },
 ]
 manifests = [{ name = "packaging" }]
 static = [
@@ -685,6 +687,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
+name = "tenacity"
+version = "9.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0a/d4/2b0cd0fe285e14b36db076e78c93766ff1d529d70408bd1d2a5a84f1d929/tenacity-9.1.2.tar.gz", hash = "sha256:1169d376c297e7de388d18b4481760d478b0e99a777cad3a9c86e556f4b697cb", size = 48036, upload-time = "2025-04-02T08:25:09.966Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/30/643397144bfbfec6f6ef821f36f33e57d35946c44a2352d3c9f0ae847619/tenacity-9.1.2-py3-none-any.whl", hash = "sha256:f77bf36710d8b73a50b2dd155c97b870017ad21afe6ab300326b0371b3b05138", size = 28248, upload-time = "2025-04-02T08:25:07.678Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Overview
This pull request refactors and expands the integration test suite for the Rawfile LocalPV charm.

* Refactored the test file to use three themed test classes: `TestDeployment`, `TestStorageProvisioning`, and `TestVolumeLifecycle`.
* Added `test_deploy_pools` to verify multi-pool charm deployment with node selectors and independent storage classes, and `test_storage_classes_created` to ensure storage classes are created as expected.
* Implemented `test_multiple_providers` to validate that PVCs are provisioned and bound to the correct storage pools, pods are scheduled appropriately, and data is correctly written/read for each pool.
* Added `test_volume_deletion_with_delete_policy` and `test_volume_retain_policy` to verify correct behavior for 'Delete' and 'Retain' reclaim policies, including PV deletion or retention after PVC removal, and proper cleanup of resources.